### PR TITLE
refactor: remove unstable Option<&T> branch by returning owned Tensor

### DIFF
--- a/src/models/deepseek_ocr/generate.rs
+++ b/src/models/deepseek_ocr/generate.rs
@@ -205,7 +205,7 @@ impl GenerateModel for DeepseekOCRGenerateModel {
                     decode_ids.extend_from_slice(&error_tokens);
                 }
                 decode_ids.push(next_token);
-                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{}", e)))?;
+                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{e}")))?;
                 if decoded_token.contains("�") {
                     error_tokens.push(next_token);
                     if error_tokens.len() > 3 {

--- a/src/models/hunyuan_ocr/generate.rs
+++ b/src/models/hunyuan_ocr/generate.rs
@@ -183,7 +183,7 @@ impl<'a> GenerateModel for HunyuanOCRGenerateModel<'a> {
                     decode_ids.extend_from_slice(&error_tokens);
                 }
                 decode_ids.push(next_token);
-                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{}", e)))?;
+                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{e}")))?;
                 if decoded_token.contains("�") {
                     error_tokens.push(next_token);
                     if error_tokens.len() > 3 {

--- a/src/models/hunyuan_ocr/model.rs
+++ b/src/models/hunyuan_ocr/model.rs
@@ -482,20 +482,11 @@ impl HunYuanVLTextModel {
     ) -> Result<Tensor> {
         let (b_size, seq_len, _) = inputs_embeds.dims3()?;
 
-        // let position_ids = match position_ids {
-        //     Some(ids) => ids.clone(),
-        //     None => Tensor::arange(
-        //         seqlen_offset as u32,
-        //         (seq_len + seqlen_offset) as u32,
-        //         inputs_embeds.device(),
-        //     )?
-        //     .unsqueeze(0)?,
-        // };
-        let attention_mask: Option<&Tensor> = {
+        let attention_mask: Option<Tensor> = {
             if seq_len <= 1 {
                 None
             } else {
-                Some(&prepare_causal_attention_mask(
+                Some(prepare_causal_attention_mask(
                     b_size,
                     seq_len,
                     0,
@@ -514,9 +505,9 @@ impl HunYuanVLTextModel {
             {
                 let (cos, sin) =
                     get_xd_cos_sin(&cos, &sin, position_ids, self.xdrope_section.clone())?;
-                xs = layer.forward(&xs, &cos, &sin, attention_mask)?;
+                xs = layer.forward(&xs, &cos, &sin, attention_mask.as_ref())?;
             } else {
-                xs = layer.forward(&xs, &cos, &sin, attention_mask)?;
+                xs = layer.forward(&xs, &cos, &sin, attention_mask.as_ref())?;
             }
         }
         let xs = self.norm.forward(&xs)?;

--- a/src/models/minicpm4/generate.rs
+++ b/src/models/minicpm4/generate.rs
@@ -119,7 +119,7 @@ impl<'a> GenerateModel for MiniCPMGenerateModel<'a> {
                     decode_ids.extend_from_slice(&error_tokens);
                 }
                 decode_ids.push(next_token);
-                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{}", e)))?;
+                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{e}")))?;
                 if decoded_token.contains("�") {
                     error_tokens.push(next_token);
                     if error_tokens.len() > 3 {

--- a/src/models/paddleocr_vl/generate.rs
+++ b/src/models/paddleocr_vl/generate.rs
@@ -162,7 +162,7 @@ impl<'a> GenerateModel for PaddleOCRVLGenerateModel<'a> {
                     decode_ids.extend_from_slice(&error_tokens);
                 }
                 decode_ids.push(next_token);
-                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{}", e)))?;
+                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{e}")))?;
                 if decoded_token.contains("�") {
                     error_tokens.push(next_token);
                     if error_tokens.len() > 3 {

--- a/src/models/paddleocr_vl/model.rs
+++ b/src/models/paddleocr_vl/model.rs
@@ -376,11 +376,11 @@ impl Ernie4_5Model {
             self.rope_scaling.mrope_section.clone(),
         )?;
         let mut xs = inputs_embeds.clone();
-        let attention_mask: Option<&Tensor> = {
+        let attention_mask: Option<Tensor> = {
             if seq_len <= 1 {
                 None
             } else {
-                Some(&prepare_causal_attention_mask(
+                Some(prepare_causal_attention_mask(
                     b_size,
                     seq_len,
                     0,
@@ -389,7 +389,7 @@ impl Ernie4_5Model {
             }
         };
         for layer in self.layers.iter_mut() {
-            xs = layer.forward(&xs, &cos, &sin, attention_mask)?;
+            xs = layer.forward(&xs, &cos, &sin, attention_mask.as_ref())?;
         }
         let xs = xs.apply(&self.norm)?;
         Ok(xs)
@@ -564,7 +564,7 @@ impl PaddleOCRVLModel {
                         }
                     }
                     Err(e) => {
-                        println!("get vision_indices err: {}", e);
+                        println!("get vision_indices err: {e}");
                     }
                 };
 

--- a/src/models/qwen2_5vl/generate.rs
+++ b/src/models/qwen2_5vl/generate.rs
@@ -189,7 +189,7 @@ impl<'a> GenerateModel for Qwen2_5VLGenerateModel<'a> {
                     decode_ids.extend_from_slice(&error_tokens);
                 }
                 decode_ids.push(next_token);
-                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{}", e)))?;
+                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{e}")))?;
                 if decoded_token.contains("�") {
                     error_tokens.push(next_token);
                     if error_tokens.len() > 3 {

--- a/src/models/qwen2_5vl/model.rs
+++ b/src/models/qwen2_5vl/model.rs
@@ -713,11 +713,11 @@ impl Qwen2_5VLTextModel {
             self.rope_scaling.mrope_section.clone(),
         )?;
         let mut xs = inputs_embeds.clone();
-        let attention_mask: Option<&Tensor> = {
+        let attention_mask: Option<Tensor> = {
             if seq_len <= 1 {
                 None
             } else {
-                Some(&prepare_causal_attention_mask(
+                Some(prepare_causal_attention_mask(
                     b_size,
                     seq_len,
                     0,
@@ -726,7 +726,7 @@ impl Qwen2_5VLTextModel {
             }
         };
         for layer in self.layers.iter_mut() {
-            xs = layer.forward(&xs, &cos, &sin, attention_mask)?;
+            xs = layer.forward(&xs, &cos, &sin, attention_mask.as_ref())?;
         }
         let xs = xs.apply(&self.norm)?;
         Ok(xs)
@@ -898,7 +898,7 @@ impl Qwen2_5VLModel {
                         }
                     }
                     Err(e) => {
-                        println!("get vision_indices err: {}", e);
+                        println!("get vision_indices err: {e}");
                     }
                 };
 

--- a/src/models/qwen2_5vl/processor.rs
+++ b/src/models/qwen2_5vl/processor.rs
@@ -243,7 +243,7 @@ impl Qwen2_5VLProcessor {
                     let image = get_image(file);
                     match image {
                         Ok(img) => file_vec.push(img),
-                        Err(e) => println!("get_image err: {:?}", e),
+                        Err(e) => println!("get_image err: {e:?}"),
                     };
                 }
                 if !file_vec.is_empty() {
@@ -253,7 +253,7 @@ impl Qwen2_5VLProcessor {
                             pixel_values = Some(img_input.data);
                             image_grid_thw = Some(img_input.grid_thw);
                         }
-                        Err(e) => println!("img process_images err: {:?}", e),
+                        Err(e) => println!("img process_images err: {e:?}"),
                     };
                 }
             }

--- a/src/models/qwen3vl/generate.rs
+++ b/src/models/qwen3vl/generate.rs
@@ -191,7 +191,7 @@ impl<'a> GenerateModel for Qwen3VLGenerateModel<'a> {
                     decode_ids.extend_from_slice(&error_tokens);
                 }
                 decode_ids.push(next_token);
-                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{}", e)))?;
+                let decoded_token = self.tokenizer.token_decode(decode_ids).map_err(|e| anyhow!(format!("stream decode error{e}")))?;
                 if decoded_token.contains("�") {
                     error_tokens.push(next_token);
                     if error_tokens.len() > 3 {

--- a/src/models/qwen3vl/processor.rs
+++ b/src/models/qwen3vl/processor.rs
@@ -310,7 +310,7 @@ impl Qwen3VLProcessor {
                     let image = get_image(file);
                     match image {
                         Ok(img) => file_vec.push(img),
-                        Err(e) => println!("get_image err: {:?}", e),
+                        Err(e) => println!("get_image err: {e:?}"),
                     };
                 }
                 if !file_vec.is_empty() {
@@ -320,7 +320,7 @@ impl Qwen3VLProcessor {
                             pixel_values = Some(img_input.data);
                             image_grid_thw = Some(img_input.grid_thw);
                         }
-                        Err(e) => println!("img process_images err: {:?}", e),
+                        Err(e) => println!("img process_images err: {e:?}"),
                     };
                 }
             }
@@ -435,14 +435,12 @@ pub fn video_smart_resize(
 ) -> Result<(u32, u32)> {
     if num_frames < temporal_factor {
         return Err(anyhow!(format!(
-            "{} must be larger than temporal_factor {}",
-            num_frames, temporal_factor
+            "{num_frames} must be larger than temporal_factor {temporal_factor}"
         )));
     }
     if height < factor || width < factor {
         return Err(anyhow!(format!(
-            "height:{} or width:{} must be larger than factor:{}",
-            height, width, factor
+            "height:{height} or width:{width} must be larger than factor:{factor}"
         )));
     }
     if std::cmp::max(height, width) / std::cmp::min(height, width) > 200 {

--- a/src/models/voxcpm/tokenizer.rs
+++ b/src/models/voxcpm/tokenizer.rs
@@ -19,7 +19,7 @@ impl SingleChineseTokenizer {
             "tokenizer.json not exists in model path"
         );
         let tokenizer = Tokenizer::from_file(tokenizer_file)
-            .map_err(|e| anyhow!(format!("tokenizer from file error{}", e)))?;
+            .map_err(|e| anyhow!(format!("tokenizer from file error{e}")))?;
         let mut multichar_tokens = Vec::new();
         for (token, _) in tokenizer.get_vocab(false) {
             let len = token.chars().count();
@@ -42,7 +42,7 @@ impl SingleChineseTokenizer {
         let encode = self
             .tokenizer
             .encode(text, false)
-            .map_err(|e| anyhow!(format!("tokenizer encode error: {}", e)))?;
+            .map_err(|e| anyhow!(format!("tokenizer encode error: {e}")))?;
         let tokens = encode.get_tokens();
         // println!("tokens: {:?}", tokens);
         let mut split_character = Vec::new();


### PR DESCRIPTION
Replaced the previous Option<&Tensor> conditional construction with an owned Option<Tensor> to avoid relying on unstable temporary reference behavior.

This refactor simplifies the control flow, removes unnecessary borrowing, and ensures the project can be built and edited entirely with stable Rust.

All tests have been verified to pass on the Rust 1.88.0 stable release.